### PR TITLE
also specify edition

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -2,4 +2,4 @@
 
 Copyright for Apress source code belongs to the author(s). However, under fair use you are encouraged to fork and contribute minor corrections and updates for the benefit of the author(s) and other readers.
 
-If you have trouble getting this book's examples to work, please contact the author at adam@adam-freeman.com for help. Please make it clear in your email which book you are reading and which chapter/example is causing the problem.
+If you have trouble getting this book's examples to work, please contact the author at adam@adam-freeman.com for help. Please make it clear in your email which book [and edition as the ISBN usually unchanged across releases] you are reading and which chapter/example is causing the problem.


### PR DESCRIPTION
Adam & Apress obligingly publish new editions to match product releases often, but the ISBN kept the same. Unfortunately the frontispiece copyright page omits the release history, but should still be clear which edition you have and are contributing feedback.